### PR TITLE
Override starting pritunl profile

### DIFF
--- a/src/pritunl/profile.ts
+++ b/src/pritunl/profile.ts
@@ -10,6 +10,9 @@ const getProfiles = () => {
 };
 
 export const getProfileId = (): string => {
+  if (process.env.PRITUNL_CTL_PROFILE_ID) {
+    return process.env.PRITUNL_CTL_PROFILE_ID;
+  }
   const profile = getProfiles()[0];
   if (!profile) throw new Error('Could not find Pritunl profile.');
   const [profileId] = profile.split('.');


### PR DESCRIPTION
does not quite work when i have multiple pritunl profiles as it always picks the first one, added an env var to override this behavior

usage: 
to list all profiles: `ls ~/Library/Application\ Support/pritunl/profiles | grep '.conf$' | awk -F"." '{print $1}`
and start: `env PRITUNL_CTL_PROFILE_ID=eac3c269909174ae78bf6b7429815d78 ./bin/pritunlctl.js start`
